### PR TITLE
decrypt support - `encrypted?` and `decrypt` operations on `Mail::Message`

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,24 @@ updating it's db when necessary.
 You may also want to have a look at the [GPGME](https://github.com/ueno/ruby-gpgme) docs and code base for more info on the various options, especially regarding the `passphrase_callback` arguments.
 
 
+### Decrypting
+
+Receive the mail as usual. Check if it is encrypted using the `encrypted?` method. Get a decrypted version of the mail with the `decrypt` method:
+
+```ruby
+mail = Mail.first
+mail.subject # subject is never encrypted
+if mail.encrypted?
+  # decrypt using your private key, protected by the given passphrase
+  plaintext_mail = mail.decrypt(:password => 'abc')
+  # the plaintext_mail, is a full Mail::Message object, just decrypted
+end
+```
+
+A `GPGME::Error::BadPassphrase` will be raised if the password for the private key is incorrect.
+A `EncodingError` will be raised if the encrypted mails is not encoded correctly as a [RFC 3156](http://www.ietf.org/rfc/rfc3156.txt) message.
+
+
 ### Signing only
 
 Just leave the the `:encrypt` option out or pass `encrypt: false`, i.e.

--- a/lib/mail/gpg.rb
+++ b/lib/mail/gpg.rb
@@ -54,16 +54,19 @@ module Mail
 		end
 
     def self.decrypt(encrypted_mail, options = {})
-      if (encrypted_mail.has_content_type? && 
-          'multipart/encrypted' == encrypted_mail.mime_type &&
-          'application/pgp-encrypted' == encrypted_mail.content_type_parameters[:protocol])
-         
+      if (encrypted?(encrypted_mail))
          decrypt_pgp_mime(encrypted_mail, options)
       else
         raise EncodingError, "Unsupported encryption format '#{encrypted_mail.content_type}'"
       end
     end
     
+    def self.encrypted?(mail)
+      mail.has_content_type? &&
+        'multipart/encrypted' == mail.mime_type &&
+        'application/pgp-encrypted' == mail.content_type_parameters[:protocol]
+    end
+
     private
 
 		def self.construct_mail(cleartext_mail, options, &block)	

--- a/lib/mail/gpg/message_patch.rb
+++ b/lib/mail/gpg/message_patch.rb
@@ -51,6 +51,14 @@ module Mail
         end
       end
 
+      def encrypted?
+        Mail::Gpg.encrypted?(self)
+      end
+
+      def decrypt(options = {})
+        Mail::Gpg.decrypt(self, options)
+      end
+
     end
   end
 end


### PR DESCRIPTION
Added the proposed `encrypted?` and `decrypt` operations as suggested in [pull request #2](https://github.com/jkraemer/mail-gpg/pull/2#issuecomment-25879929).

Updated README.md with section on decryption.
