### PR TITLE
Signature check operations for RFC3256 signed messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,13 +96,15 @@ if mail.encrypted?
 end
 ```
 
+Set the `:verify` option to `true` when calling `decrypt` to decrypt *and* verify signatures.
+
 A `GPGME::Error::BadPassphrase` will be raised if the password for the private key is incorrect.
 A `EncodingError` will be raised if the encrypted mails is not encoded correctly as a [RFC 3156](http://www.ietf.org/rfc/rfc3156.txt) message.
 
 
 ### Signing only
 
-Just leave the the `:encrypt` option out or pass `encrypt: false`, i.e.
+Just leave the `:encrypt` option out or pass `encrypt: false`, i.e.
 
 
     Mail.new do
@@ -110,6 +112,21 @@ Just leave the the `:encrypt` option out or pass `encrypt: false`, i.e.
       gpg sign: true
     end.deliver 
 
+### Verify signature(s)
+
+Receive the mail as usual. Check if it is signed using the `signed?` method. Check the signature of the mail with the `signature_valid?` method:
+
+```ruby
+mail = Mail.first
+if !mail.encrypted? && mail.signed?
+  # do not call signed on encrypted mails. The signature on encrypted mails
+  # must be checked by setting the :verify option when decrypting
+  puts "signature(s) valid: #{mail.signature_valid?}"
+end
+```
+
+Note that for encrypted mails the signatures can not be checked using these methods. For encrypted mails
+the `:verify` option for the `decrypt` operation must be used instead.
 
 ### Key import from public key servers
 
@@ -163,7 +180,7 @@ around with your personal gpg keychain.
 
 ## Todo
 
-* signature verification for received mails
+* signature verification for received mails with inline PGP
 * on the fly import of recipients' keys from public key servers based on email address or key id
 * handle encryption errors due to missing keys - maybe return a list of failed
   recipients

--- a/lib/mail/gpg/gpgme_helper.rb
+++ b/lib/mail/gpg/gpgme_helper.rb
@@ -72,6 +72,15 @@ module Mail
         crypto.sign GPGME::Data.new(plain), options
       end
 
+      def self.sign_verify(plain, signature, options = {})
+        signed = false
+        GPGME::Crypto.new.verify(signature, signed_text: plain) do |sig|
+          return false if !sig.valid? # just one invalid signature leads to false
+          signed = true
+        end
+        return signed
+      end
+
       private
 
       # normalizes the list of recipients' emails, key ids and key data to a

--- a/lib/mail/gpg/message_patch.rb
+++ b/lib/mail/gpg/message_patch.rb
@@ -59,6 +59,13 @@ module Mail
         Mail::Gpg.decrypt(self, options)
       end
 
+      def signed?
+        Mail::Gpg.signed?(self)
+      end
+
+      def signature_valid?(options = {})
+        Mail::Gpg.signature_valid?(self, options)
+      end
     end
   end
 end

--- a/lib/mail/gpg/sign_part.rb
+++ b/lib/mail/gpg/sign_part.rb
@@ -11,6 +11,14 @@ module Mail
           content_description 'OpenPGP digital signature'
         end
       end
+
+      def self.signature_valid?(plain, signature, options = {})
+        if !(signature.has_content_type? && ('application/pgp-signature' == signature.mime_type))
+          return false
+        end
+
+        GpgmeHelper.sign_verify(plain.encoded, signature.body.encoded, options)
+      end
     end
   end
 end

--- a/test/gpg_test.rb
+++ b/test/gpg_test.rb
@@ -29,15 +29,17 @@ class GpgTest < Test::Unit::TestCase
   end
 
   def check_signature(mail = @mail, signed = @signed)
+    assert signed.signed?
     assert signature = signed.parts.detect{|p| p.content_type =~ /signature\.asc/}.body.to_s
     GPGME::Crypto.new.verify(signature, signed_text: mail.encoded) do |sig|
       assert true == sig.valid?
     end
+    assert Mail::Gpg.signature_valid?(signed)
   end
 
   def check_mime_structure_signed(mail = @mail, signed = @signed)
     assert_equal 2, signed.parts.size
-    sign_part, orig_part = signed.parts
+    orig_part, sign_part = signed.parts
 
     assert_equal 'application/pgp-signature; name=signature.asc', sign_part.content_type
     assert_equal orig_part.content_type, @mail.content_type
@@ -146,7 +148,7 @@ class GpgTest < Test::Unit::TestCase
       end
 
       should 'have multiple parts in original content' do
-        assert original_part = @signed.parts.last
+        assert original_part = @signed.parts.first
         assert original_part.multipart?
         assert_equal 2, original_part.parts.size
         assert_match /sign me!/, original_part.parts.first.body.to_s

--- a/test/sign_part_test.rb
+++ b/test/sign_part_test.rb
@@ -1,15 +1,20 @@
+require 'test_helper'
 require 'mail/gpg/sign_part'
 
 class SignPartTest < Test::Unit::TestCase
 	context 'SignPart' do
 		setup do
-			mail = Mail.new do
+			@mail = Mail.new do
 				to 'jane@foo.bar'
 				from 'joe@foo.bar'
 				subject 'test'
 				body 'i am unsigned'
 			end
-			@part = Mail::Gpg::SignPart.new(mail)
+		end
+
+		should 'roundtrip successfully' do
+			signature_part = Mail::Gpg::SignPart.new(@mail, password: 'abc')
+			assert Mail::Gpg::SignPart.signature_valid?(@mail, signature_part)
 		end
 	end
 end


### PR DESCRIPTION
Implemented `signed?`and `signature_valid?` operations for checking signatures on signed-only mails.

Implemented as discussed in [pull request #2.](https://github.com/jkraemer/mail-gpg/pull/2#issuecomment-27772061), meaning that `signed?` throws an error if called on `encrypted` mails.

For encrypted emails the signature should be verified as part of `decrypt`by setting the `:verify`option.

Added documentation section on this in _Verify signature(s)_ section.

Note that this does not yet support `signature_valid?` for so called \* Inline GPG\* messages (added to todo list)
