### PR TITLE
Raise Exception if no usable key is present

### DIFF
--- a/lib/mail/gpg/gpgme_helper.rb
+++ b/lib/mail/gpg/gpgme_helper.rb
@@ -11,6 +11,10 @@ module Mail
 
         recipient_keys = keys_for_data options[:recipients], options.delete(:keys)
 
+        if recipient_keys.empty?
+          raise MissingKeysError.new('No keys to encrypt to!')
+        end
+
         flags = 0
         flags |= GPGME::ENCRYPT_ALWAYS_TRUST if options[:always_trust]
 

--- a/lib/mail/gpg/missing_keys_error.rb
+++ b/lib/mail/gpg/missing_keys_error.rb
@@ -1,0 +1,2 @@
+class MissingKeysError < StandardError
+end


### PR DESCRIPTION
`GPGME#encrypt()/#encrypt_sign` raise GPGME::Error::InvalidValue if the list of public keys to encrypt with is empty. This small patch checkes for the key list not being empty before handing it over.
