### PR TITLE
Pass on Message-ID if set when encrypting/signing.

### DIFF
--- a/lib/mail/gpg.rb
+++ b/lib/mail/gpg.rb
@@ -113,6 +113,9 @@ module Mail
             self.header[field] = h.value
           end
         end
+        if cleartext_mail.message_id
+          header['Message-ID'] = cleartext_mail['Message-ID'].value
+        end
         cleartext_mail.header.fields.each do |field|
           if MORE_HEADERS.include?(field.name) or field.name =~ /^X-/
             header[field.name] = field.value


### PR DESCRIPTION
Previously a specified Message-ID was swallowed by the
encrypting/signing-process which made Mail generate new ones.

Now you can specify your own Message-IDs like in stock Mail.
