### PR TITLE
Add Rails 5 to the Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,5 @@ matrix:
       env: RAILS=5.0.0.0
 before_install:
   - gem update bundler
+sudo: false
+cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,5 @@ matrix:
   exclude:
     - rvm: 2.1.9
       env: RAILS=5.0.0.0
+before_install:
+  - gem update bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 language: ruby
 rvm:
-  - 2.3.0
-  - 2.2.4
-  - 2.1.8
+  - 2.3.1
+  - 2.2.5
+  - 2.1.9
 env:
   - RAILS=3.2.22.1
   - RAILS=4.1.14.1
   - RAILS=4.2.5.1
+  - RAILS=5.0.0.0
+matrix:
+  exclude:
+    - rvm: 2.1.9
+      env: RAILS=5.0.0.0

--- a/test/gpg_test.rb
+++ b/test/gpg_test.rb
@@ -14,7 +14,7 @@ class GpgTest < Test::Unit::TestCase
     v_part, enc_part = encrypted.parts
 
     assert_match /Version: 1/, v_part.to_s
-    assert_equal 'application/pgp-encrypted; charset=UTF-8', v_part.content_type
+    assert_match /application\/pgp-encrypted(?:; charset=UTF-8)?/, v_part.content_type
 
     assert_equal 'application/octet-stream; name=encrypted.asc',
     enc_part.content_type


### PR DESCRIPTION
* Introduce CI with Rails 5 on ruby >= 2.2.
* Bump Rails and Ruby versions for the CI builds.
* Enable bundler cache and use of the container systems on Travis to speed up build times.
* Solve bundle installation failures by updating it beforehand.
* Fix a few test failures that cropped up because of a missing charset in the content type (unrelated to the changes in this PR in any other way).