### PR TITLE
Fix replying to InlineDecryptedMessage, InlineSignedMessage, MimeSign…

### DIFF
--- a/lib/mail/gpg.rb
+++ b/lib/mail/gpg.rb
@@ -151,14 +151,14 @@ module Mail
 
     # decrypts inline PGP encrypted mail
     def self.decrypt_pgp_inline(encrypted_mail, options)
-      InlineDecryptedMessage.new(encrypted_mail, options)
+      InlineDecryptedMessage.setup(encrypted_mail, options)
     end
 
     def self.verify(signed_mail, options = {})
       if signed_mime?(signed_mail)
-        Mail::Gpg::MimeSignedMessage.new signed_mail, options
+        Mail::Gpg::MimeSignedMessage.setup signed_mail, options
       elsif signed_inline?(signed_mail)
-        Mail::Gpg::InlineSignedMessage.new signed_mail, options
+        Mail::Gpg::InlineSignedMessage.setup signed_mail, options
       else
         signed_mail
       end

--- a/lib/mail/gpg/inline_decrypted_message.rb
+++ b/lib/mail/gpg/inline_decrypted_message.rb
@@ -12,9 +12,9 @@ module Mail
       # options are:
       #
       # :verify: decrypt and verify
-      def initialize(cipher_mail, options = {})
+      def self.setup(cipher_mail, options = {})
         if cipher_mail.multipart?
-          super() do
+          self.new do
             cipher_mail.header.fields.each do |field|
               header[field.name] = field.value
             end
@@ -48,7 +48,7 @@ module Mail
           end # of multipart
         else
           decrypted = cipher_mail.body.empty? ? '' : GpgmeHelper.decrypt(cipher_mail.body.decoded, options)
-          super() do
+          self.new do
             cipher_mail.header.fields.each do |field|
               header[field.name] = field.value
             end

--- a/lib/mail/gpg/inline_signed_message.rb
+++ b/lib/mail/gpg/inline_signed_message.rb
@@ -4,9 +4,9 @@ module Mail
   module Gpg
     class InlineSignedMessage < Mail::Message
 
-      def initialize(signed_mail, options = {})
+      def self.setup(signed_mail, options = {})
         if signed_mail.multipart?
-          super() do
+          self.new do
             global_verify_result = []
             signed_mail.header.fields.each do |field|
               header[field.name] = field.value
@@ -29,7 +29,7 @@ module Mail
             verify_result global_verify_result
           end # of multipart
         else
-          super() do
+          self.new do
             signed_mail.header.fields.each do |field|
               header[field.name] = field.value
             end

--- a/lib/mail/gpg/mime_signed_message.rb
+++ b/lib/mail/gpg/mime_signed_message.rb
@@ -4,10 +4,10 @@ module Mail
   module Gpg
     class MimeSignedMessage < Mail::Message
 
-      def initialize(signed_mail, options = {})
+      def self.setup(signed_mail, options = {})
         content_part, signature = signed_mail.parts
         success, vr = SignPart.verify_signature(content_part, signature, options)
-        super() do
+        self.new do
           verify_result vr
           signed_mail.header.fields.each do |field|
             header[field.name] = field.value


### PR DESCRIPTION
…edMessage.

Mail::Message#initialize has a different signature than our classes had,
which broke replying. Without overwriting initialize() it works well.

Fixes #30.