### PR TITLE
test/test_helper.rb: Requires open3

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
+require 'open3'
 require 'test/unit'
 require 'shoulda/context'
 require 'mail-gpg'


### PR DESCRIPTION
It seems the pull request #37 wasn't complete. This one makes the tests finally work with GnuPG 2.1. Would be great if this could be merged. Thanks!