### PR TITLE
Strip "headers" when stripping inline signature.

### DIFF
--- a/lib/mail/gpg/inline_signed_message.rb
+++ b/lib/mail/gpg/inline_signed_message.rb
@@ -62,7 +62,8 @@ module Mail
           signed_text.gsub! INLINE_SIG_RE, ''
           signed_text.strip!
         end
-        signed_text
+        # Strip possible inline-"headers" (e.g. "Hash: SHA256", or "Comment: something").
+        signed_text.gsub(/(.*^-----BEGIN PGP SIGNED MESSAGE-----\n)(.*?)^$(.+)/m, '\1\3')
       end
 
     end

--- a/test/inline_signed_message_test.rb
+++ b/test/inline_signed_message_test.rb
@@ -19,7 +19,7 @@ class InlineSignedMessageTest < Test::Unit::TestCase
       should 'strip signature from signed text' do
         body = self.class.inline_sign(@mail, 'i am signed')
         assert stripped_body = Mail::Gpg::InlineSignedMessage.strip_inline_signature(body)
-        assert_equal "-----BEGIN PGP SIGNED MESSAGE-----\nHash: SHA1\n\ni am signed\n-----END PGP SIGNED MESSAGE-----", stripped_body
+        assert_equal "-----BEGIN PGP SIGNED MESSAGE-----\n\ni am signed\n-----END PGP SIGNED MESSAGE-----", stripped_body
       end
 
       should 'not change unsigned text' do


### PR DESCRIPTION
Marking the begin and end of the signed text helps to identify later,
which section of the text was actually signed.  We don't need these
"headers" for that purpose, they only irritate humans.

Closes #42 