### PR TITLE
Copy Date-header to decrypted message.

### DIFF
--- a/lib/mail/gpg.rb
+++ b/lib/mail/gpg.rb
@@ -136,7 +136,7 @@ module Mail
       end
       decrypted = DecryptedPart.new(encrypted_mail.parts[1], options)
       Mail.new(decrypted.raw_source) do
-        %w(from to cc bcc subject reply_to in_reply_to).each do |field|
+        %w(from to cc bcc subject reply_to in_reply_to date).each do |field|
           send field, encrypted_mail.send(field)
         end
         # copy header fields


### PR DESCRIPTION
Until there's a good solution how to deal with headers (#24) mail-gpg should copy standard headers, e.g. Date.