### PR TITLE
Fix double-decoding QP.

### DIFF
--- a/lib/mail/gpg/mime_signed_message.rb
+++ b/lib/mail/gpg/mime_signed_message.rb
@@ -18,13 +18,11 @@ module Mail
           if content_part.multipart?
             content_part.parts.each{|part| add_part part}
           else
-            body content_part.body.to_s
+            body content_part.body.raw_source
           end
         end
       end
     end
   end
 end
-
-
 


### PR DESCRIPTION
The code copies all email-headers unchanged and unfiltered, so it must
copy the body unchanged, too.

Otherwise a double-decoding of the body will occur, which leads to
stripped trailing equal-signs (because they are considered "soft line
breaks" in compliance with RFC 2045, Section 6.7, paragraph 5).